### PR TITLE
feat: allow yml lang on route custom block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .DS_Store
 dist
+# intellij/webstorm stuff
+.idea/

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -38,7 +38,7 @@ export function parseCustomBlock(block: CustomBlock, filePath: string, options: 
     } catch (err) {
       throw new Error(`Invalid JSON format of <${block.type}> content in ${filePath}\n${err.message}`)
     }
-  } else if (lang === 'yaml') {
+  } else if (lang === 'yaml' || lang === 'yml') {
     try {
       return YAML.parse(block.content)
     } catch (err) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ interface Options {
    * Set default route block parser, or use `<route lang=xxx>` in SFC route block
    * @default 'json5'
    */
-  routeBlockLang: 'json5' | 'json' | 'yaml'
+  routeBlockLang: 'json5' | 'json' | 'yaml' | 'yml'
   /**
    * Replace '[]' to '_' in bundle chunk filename
    * Experimental feature


### PR DESCRIPTION
closes #64

Also added `.idea/` directory to be excluded on `.gitignore` (intellj/webstorm stuff).