### PR TITLE
fix(generate): use repeated params for catch all

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -99,7 +99,7 @@ export function generateRoutes(pages: ResolvedPages, options: ResolvedOptions): 
           route.path += `/:${normalizedName}`
           // Catch-all route
           if (isCatchAll)
-            route.path += '(.*)'
+            route.path += '(.*)*'
         } else {
           route.path += `/${normalizedPath}`
         }


### PR DESCRIPTION
The catch all route should define a repeated params to handle `/` correctly when doing relative locations. The difference can be seen at https://paths.esm.dev/?p=AAMeJbiAwQEcDKbAoAAAHQmogU4AQQ..&t=/anything/goes# vs https://paths.esm.dev/?p=AAMeJbiAwQEcDKbAoAAAHQmoKEAAIA..&t=/anything/goes#

https://github.com/vuejs/vue-router-next/issues/1020

I haven't checked how this affect other routers but **my proposal only concerns vue router**