### PR TITLE
fix: add client types into exports, close #118

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
       "require": "./dist/index.js",
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
+    },
+    "./client": {
+      "types": "./client.d.ts"
+    },
+    "./client-react": {
+      "types": "./client-react.d.ts"
     }
   },
   "main": "dist/index.js",


### PR DESCRIPTION
TypeScript use the "exports" field for types resolution after 4.5.0. Add those client type definitions to the exports field too.