### PR TITLE
fix: Path comparison when add files

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -56,7 +56,7 @@ export class PageContext {
         path = slash(path)
         if (!isTarget(path, this.options))
           return
-        const page = this.options.dirs.find(i => path.startsWith(slash(resolve(i.dir))))!
+        const page = this.options.dirs.find(i => path.startsWith(slash(resolve(this.root, i.dir))))!
         await this.addPage(path, page)
         this.onUpdate()
       })

--- a/src/context.ts
+++ b/src/context.ts
@@ -56,7 +56,7 @@ export class PageContext {
         path = slash(path)
         if (!isTarget(path, this.options))
           return
-        const page = this.options.dirs.find(i => path.startsWith(`/${i.dir}`))!
+        const page = this.options.dirs.find(i => path.startsWith(slash(resolve(i.dir))))!
         await this.addPage(path, page)
         this.onUpdate()
       })


### PR DESCRIPTION
Unify the comparison between relative and absolute paths and fix #139 .

There is one difference from the suggestion, I changed the path resolve method from `resolve(i.dir)` to `resolve(this.root, i.dir)` to suit other code styles.