### PR TITLE
feat: add void type on onRoutesGenerated hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ export default {
 
 ### onRoutesGenerated
 
-- **Type:** `(routes: Route[]) => Route[] | void | Promise<Route[] | void>`
+- **Type:** `(routes: Route[]) => Route[] | void | Promise<Route[] | void> | void`
 
 A function that takes a generated routes and optionally returns a modified
 generated routes.

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,7 @@ interface Options {
   /**
    * Custom generated routes
    */
-  onRoutesGenerated?: (routes: any[]) => any[] | Promise<any[] | void>
+  onRoutesGenerated?: (routes: any[]) => any[] | Promise<any[] | void> | void
   /**
    * Custom generated client code
    */


### PR DESCRIPTION
Using onRoutesGenerated hook on personal project may not have to force to return routes?