### PR TITLE
fix: update react async import mode

### DIFF
--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -54,7 +54,7 @@ export function stringifyRoutes(
         return str.replace(replaceStr, importName)
     } else {
       if (options.resolver === 'react')
-        return str.replace(replaceStr, `React.lazy(() => import('${path}'))`)
+        return str.replace(replaceStr, `React.createElement(React.lazy(() => import('${path}')))`)
       else if (options.resolver === 'solid')
         return str.replace(replaceStr, `Solid.lazy(() => import('${path}'))`)
       else


### PR DESCRIPTION
# Issues
Currently, using react with async import mode throws this error
```
react-dom.development.js:13231 Uncaught Error: Objects are not valid as a React child (found: object with keys {$$typeof, _payload, _init}). If you meant to render a collection of children, use an array instead.
    at throwOnInvalidObjectType (react-dom.development.js:13231:15)
    at reconcileChildFibers2 (react-dom.development.js:14133:7)
    at reconcileChildren (react-dom.development.js:16990:28)
    at updateContextProvider (react-dom.development.js:18699:3)
    at beginWork (react-dom.development.js:19111:14)
    at HTMLUnknownElement.callCallback2 (react-dom.development.js:3945:14)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:3994:16)
    at invokeGuardedCallback (react-dom.development.js:4056:31)
    at beginWork$1 (react-dom.development.js:23964:7)
    at performUnitOfWork (react-dom.development.js:22776:12)
```
# Solution
`React.lazy` returns a `component` not a React `element`  therefore the returntype of `React.lazy `needs to be invoked either by **jsx** or `React.createElement`.