### PR TITLE
WIP: Add cross-plugin support for generated routes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,11 @@ function pagesPlugin(userOptions: UserOptions = {}): Plugin {
       ctx.setLogger(config.logger)
       await ctx.searchGlob()
     },
+    api: {
+      getResolvedRoutes() {
+        return ctx.options.resolver.getComputedRoutes(ctx)
+      },
+    },
     configureServer(server) {
       ctx.setupViteServer(server)
     },

--- a/src/resolvers/react.ts
+++ b/src/resolvers/react.ts
@@ -45,7 +45,7 @@ function prepareRoutes(
   return routes
 }
 
-async function resolveReactRoutes(ctx: PageContext) {
+async function computeReactRoutes(ctx: PageContext): Promise<ReactRoute[]> {
   const { routeStyle, caseSensitive } = ctx.options
   const nuxtStyle = routeStyle === 'nuxt'
 
@@ -107,6 +107,11 @@ async function resolveReactRoutes(ctx: PageContext) {
 
   finalRoutes = (await ctx.options.onRoutesGenerated?.(finalRoutes)) || finalRoutes
 
+  return finalRoutes
+}
+
+async function resolveReactRoutes(ctx: PageContext) {
+  const finalRoutes = await computeReactRoutes(ctx)
   let client = generateClientCode(finalRoutes, ctx.options)
   client = (await ctx.options.onClientGenerated?.(client)) || client
   return client
@@ -122,6 +127,9 @@ export function ReactResolver(): PageResolver {
     },
     async resolveRoutes(ctx) {
       return resolveReactRoutes(ctx)
+    },
+    async getComputedRoutes(ctx) {
+      return computeReactRoutes(ctx)
     },
     stringify: {
       component: path => `React.createElement(${path})`,

--- a/src/resolvers/solid.ts
+++ b/src/resolvers/solid.ts
@@ -41,7 +41,7 @@ function prepareRoutes(
   return routes
 }
 
-async function resolveSolidRoutes(ctx: PageContext) {
+async function computeSolidRoutes(ctx: PageContext): Promise<SolidRoute[]> {
   const { routeStyle, caseSensitive } = ctx.options
   const nuxtStyle = routeStyle === 'nuxt'
 
@@ -108,6 +108,11 @@ async function resolveSolidRoutes(ctx: PageContext) {
 
   finalRoutes = (await ctx.options.onRoutesGenerated?.(finalRoutes)) || finalRoutes
 
+  return finalRoutes
+}
+
+async function resolveSolidRoutes(ctx: PageContext) {
+  const finalRoutes = await computeSolidRoutes(ctx)
   let client = generateClientCode(finalRoutes, ctx.options)
   client = (await ctx.options.onClientGenerated?.(client)) || client
   return client
@@ -123,6 +128,9 @@ export function SolidResolver(): PageResolver {
     },
     async resolveRoutes(ctx) {
       return resolveSolidRoutes(ctx)
+    },
+    async getComputedRoutes(ctx) {
+      return computeSolidRoutes(ctx)
     },
     stringify: {
       dynamicImport: path => `Solid.lazy(() => import("${path}"))`,

--- a/src/resolvers/vue.ts
+++ b/src/resolvers/vue.ts
@@ -60,7 +60,7 @@ function prepareRoutes(
   return routes
 }
 
-async function resolveVueRoutes(ctx: PageContext, customBlockMap: Map<string, CustomBlock>) {
+async function computeVueRoutes(ctx: PageContext, customBlockMap: Map<string, CustomBlock>): Promise<VueRoute[]> {
   const { routeStyle, caseSensitive } = ctx.options
 
   const pageRoutes = [...ctx.pageRouteMap.values()]
@@ -136,6 +136,12 @@ async function resolveVueRoutes(ctx: PageContext, customBlockMap: Map<string, Cu
 
   finalRoutes = (await ctx.options.onRoutesGenerated?.(finalRoutes)) || finalRoutes
 
+  return finalRoutes
+}
+
+async function resolveVueRoutes(ctx: PageContext, customBlockMap: Map<string, CustomBlock>) {
+  const finalRoutes = await computeVueRoutes(ctx, customBlockMap)
+
   let client = generateClientCode(finalRoutes, ctx.options)
   client = (await ctx.options.onClientGenerated?.(client)) || client
   return client
@@ -178,6 +184,9 @@ export function VueResolver(): PageResolver {
     },
     async resolveRoutes(ctx) {
       return resolveVueRoutes(ctx, customBlockMap)
+    },
+    async getComputedRoutes(ctx) {
+      return computeVueRoutes(ctx, customBlockMap)
     },
     hmr: {
       added: async(ctx, path) => checkCustomBlockChange(ctx, path),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { ReactRoute, SolidRoute, VueRoute } from './resolvers'
 import type { PageContext } from './context'
 import type { Awaitable } from '@antfu/utils'
 
@@ -19,6 +20,7 @@ export interface PageResolver {
   resolveModuleIds: () => string[]
   resolveExtensions: () => string[]
   resolveRoutes: (ctx: PageContext) => Awaitable<string>
+  getComputedRoutes: (ctx: PageContext) => Awaitable<VueRoute[] | ReactRoute[] | SolidRoute[]>
   stringify?: {
     dynamicImport?: (importPath: string) => string
     component?: (importName: string) => string

--- a/test/__snapshots__/options.spec.ts.snap
+++ b/test/__snapshots__/options.spec.ts.snap
@@ -26,6 +26,7 @@ exports[`Options resolve > react 1`] = `
   "onClientGenerated": undefined,
   "onRoutesGenerated": undefined,
   "resolver": {
+    "getComputedRoutes": [Function],
     "resolveExtensions": [Function],
     "resolveModuleIds": [Function],
     "resolveRoutes": [Function],
@@ -66,6 +67,7 @@ exports[`Options resolve > solid 1`] = `
   "onClientGenerated": undefined,
   "onRoutesGenerated": undefined,
   "resolver": {
+    "getComputedRoutes": [Function],
     "resolveExtensions": [Function],
     "resolveModuleIds": [Function],
     "resolveRoutes": [Function],
@@ -104,6 +106,7 @@ exports[`Options resolve > vue - custom module id 1`] = `
   "onClientGenerated": undefined,
   "onRoutesGenerated": undefined,
   "resolver": {
+    "getComputedRoutes": [Function],
     "hmr": {
       "added": [Function],
       "changed": [Function],
@@ -145,6 +148,7 @@ exports[`Options resolve > vue 1`] = `
   "onClientGenerated": undefined,
   "onRoutesGenerated": undefined,
   "resolver": {
+    "getComputedRoutes": [Function],
     "hmr": {
       "added": [Function],
       "changed": [Function],


### PR DESCRIPTION
Following #215 

I just have some problems with dependencies in tests. 
I just extracted the part that generated the routes array and exposed it in the `api` section of the rollup config

![image](https://user-images.githubusercontent.com/15092120/167437919-ad1b6546-cb12-4be1-96c4-e2f53d30e9fb.png)
![image](https://user-images.githubusercontent.com/15092120/167437928-4e05a2a3-6640-44a2-b800-812b7195d257.png)

(It seems pnpm didn't installed correctly the exemples deps)
