### PR TITLE
feat: yaml in comment style custom route block for vue with jsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,29 @@ To enable syntax highlighting `<route>` in VS Code using [Vetur's Custom Code Bl
  3. Restart VS Code to get syntax highlighting for custom blocks.
 
 
+### JSX/TSX YAML format comments for Route Data(In Vue)
+
+Add route meta to the route by adding a comment block starts with `route` to the JSX or TSX file(In Vue). This will be directly added to the route after it is generated, and will override it.
+
+This feature only support JSX/TSX in vue, and will parse only the first block of comments which should also start with `route`.
+
+Now only `yaml` parser supported.
+
+- **Type:** `'vue'`
+- **Supported parser:** YAML
+
+```jsx
+/*
+route
+
+name: name-override
+meta:
+  requiresAuth: false
+  id: 1234
+  string: "1234"
+*/
+```
+
 ## File System Routing
 
 Inspired by the routing from

--- a/examples/vue/src/pages/jsx.jsx
+++ b/examples/vue/src/pages/jsx.jsx
@@ -1,0 +1,18 @@
+/*
+
+      route
+
+name: blog-id
+meta:
+  requiresAuth: false
+  id: 1234
+*/
+
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'TestJSX',
+  setup() {
+    return () => <div>TestJSX</div>
+  },
+})

--- a/examples/vue/src/pages/jsx.jsx
+++ b/examples/vue/src/pages/jsx.jsx
@@ -13,6 +13,7 @@ import { defineComponent } from 'vue'
 export default defineComponent({
   name: 'TestJSX',
   setup() {
+    // eslint-disable-next-line react/display-name
     return () => <div>TestJSX</div>
   },
 })

--- a/examples/vue/vite.config.ts
+++ b/examples/vue/vite.config.ts
@@ -17,7 +17,7 @@ const config = defineConfig({
         { dir: 'src/features/**/pages', baseRoute: 'features' },
         { dir: 'src/admin/pages', baseRoute: 'admin' },
       ],
-      extensions: ['vue', 'md'],
+      extensions: ['vue', 'md', 'jsx'],
       extendRoute(route: any) {
         if (route.name === 'about')
           route.props = (route: any) => ({ query: route.query.q })

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@types/debug": "^4.1.7",
     "debug": "^4.3.4",
     "deep-equal": "^2.0.5",
+    "extract-comments": "^1.1.0",
     "fast-glob": "^3.2.11",
     "json5": "^2.2.1",
     "local-pkg": "^0.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ importers:
       deep-equal: ^2.0.5
       eslint: ^8.16.0
       esno: ^0.16.3
+      extract-comments: ^1.1.0
       fast-glob: ^3.2.11
       json5: ^2.2.1
       local-pkg: ^0.4.1
@@ -38,6 +39,7 @@ importers:
       '@types/debug': 4.1.7
       debug: 4.3.4
       deep-equal: 2.0.5
+      extract-comments: 1.1.0
       fast-glob: 3.2.11
       json5: 2.2.1
       local-pkg: 0.4.1
@@ -1309,6 +1311,7 @@ packages:
       '@vue/runtime-core': 3.2.33
       '@vue/shared': 3.2.33
       csstype: 2.6.20
+    dev: false
 
   /@vue/runtime-dom/3.2.36:
     resolution: {integrity: sha512-gYPYblm7QXHVuBohqNRRT7Wez0f2Mx2D40rb4fleehrJU9CnkjG0phhcGEZFfGwCmHZRqBCRgbFWE98bPULqkg==}
@@ -2908,11 +2911,17 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
+  /esprima-extract-comments/1.1.0:
+    resolution: {integrity: sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==}
+    engines: {node: '>=4'}
+    dependencies:
+      esprima: 4.0.1
+    dev: false
+
   /esprima/4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /esquery/1.4.0:
     resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
@@ -3011,6 +3020,14 @@ packages:
     dependencies:
       is-extendable: 0.1.1
     dev: true
+
+  /extract-comments/1.1.0:
+    resolution: {integrity: sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==}
+    engines: {node: '>=6'}
+    dependencies:
+      esprima-extract-comments: 1.1.0
+      parse-code-context: 1.0.0
+    dev: false
 
   /extract-zip/2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -4313,6 +4330,11 @@ packages:
       callsites: 3.1.0
     dev: true
 
+  /parse-code-context/1.0.0:
+    resolution: {integrity: sha512-OZQaqKaQnR21iqhlnPfVisFjBWjhnMl5J9MgbP8xC+EwoVqbXrq78lp+9Zb3ahmLzrIX5Us/qbvBnaS3hkH6OA==}
+    engines: {node: '>=6'}
+    dev: false
+
   /parse-entities/2.0.0:
     resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
     dependencies:
@@ -5589,6 +5611,7 @@ packages:
       '@vue/runtime-dom': 3.2.33
       '@vue/server-renderer': 3.2.33_vue@3.2.33
       '@vue/shared': 3.2.33
+    dev: false
 
   /vue/3.2.36:
     resolution: {integrity: sha512-5yTXmrE6gW8IQgttzHW5bfBiFA6mx35ZXHjGLDmKYzW6MMmYvCwuKybANRepwkMYeXw2v1buGg3/lPICY5YlZw==}

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,15 @@ export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 export type ImportMode = 'sync' | 'async'
 export type ImportModeResolver = (filepath: string, pluginOptions: ResolvedOptions) => ImportMode
 
+export interface ParsedJSX {
+  value: string
+  loc: {
+    start: {
+      line: number
+    }
+  }
+}
+
 export type CustomBlock = Record<string, any>
 
 export type InternalPageResolvers = 'vue' | 'react' | 'solid'

--- a/test/__snapshots__/parser.spec.ts.snap
+++ b/test/__snapshots__/parser.spec.ts.snap
@@ -8,3 +8,13 @@ exports[`Parser > custom block 1`] = `
   "name": "blog-id",
 }
 `;
+
+exports[`Parser > jsx yaml comment 1`] = `
+{
+  "meta": {
+    "id": 1234,
+    "requiresAuth": false,
+  },
+  "name": "blog-id",
+}
+`;

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -3,10 +3,16 @@ import { getRouteBlock } from '../src/customBlock'
 import { resolveOptions } from '../src/options'
 
 const options = resolveOptions({})
-const path = resolve('./examples/vue/src/pages/blog/[id].vue')
 
 describe('Parser', () => {
   test('custom block', async() => {
+    const path = resolve('./examples/vue/src/pages/blog/[id].vue')
+    const routeBlock = await getRouteBlock(path, options)
+    expect(routeBlock).toMatchSnapshot()
+  })
+
+  test('jsx yaml comment', async() => {
+    const path = resolve('./examples/vue/src/pages/jsx.jsx')
     const routeBlock = await getRouteBlock(path, options)
     expect(routeBlock).toMatchSnapshot()
   })


### PR DESCRIPTION
Support adding route block by parsing yaml format comment in vue JSX/TSX file.

comment must start with ```route```
```jsx
/*

      route

name: blog-id
meta:
  requiresAuth: false
  id: 1234
*/

import { defineComponent } from 'vue'

export default defineComponent({
  name: 'TestJSX',
  setup() {
    return () => <div>TestJSX</div>
  },
})

```

related issue:  https://github.com/hannoeru/vite-plugin-pages/issues/219