### PR TITLE
feat: compat to vue2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@vue/compiler-sfc": "^3.0.0",
+    "@vue/compiler-sfc": "^2.0.0 || ^3.0.0",
     "vite": "^2.0.0"
   },
   "peerDependenciesMeta": {

--- a/src/customBlock.ts
+++ b/src/customBlock.ts
@@ -76,7 +76,7 @@ export async function getRouteBlock(path: string, options: ResolvedOptions) {
   const content = fs.readFileSync(path, 'utf8')
 
   const parsedSFC = await parseSFC(content)
-  const blockStr = parsedSFC.customBlocks.find(b => b.type === 'route')
+  const blockStr = parsedSFC?.customBlocks.find(b => b.type === 'route')
 
   const parsedJSX = parseJSX(content)
 


### PR DESCRIPTION
I found a mistake here when I use this plugin with `vue@2.7.0-beta.1.`

**mini-reproduction: https://stackblitz.com/edit/vitejs-vite-md4vf7?file=vite.config.ts**

```bash
$ vite dev
[vite-plugin-pages] Cannot read properties of undefined (reading 'customBlocks')

  vite v2.9.12 dev server running at:

  > Local: http://localhost:3000/
  > Network: use `--host` to expose

  ready in 512ms.
```