### PR TITLE
fix(vue): remove index form route name when use routeNameSeparator

### DIFF
--- a/src/resolvers/vue.ts
+++ b/src/resolvers/vue.ts
@@ -34,7 +34,7 @@ function prepareRoutes(
 ) {
   for (const route of routes) {
     if (route.name)
-      route.name = route.name.replace(/-index$/, '')
+      route.name = route.name.replace(RegExp(`${ctx.options.routeNameSeparator}index$`), '')
 
     if (parent)
       route.path = route.path?.replace(/^\//, '')

--- a/test/__snapshots__/generate.spec.ts.snap
+++ b/test/__snapshots__/generate.spec.ts.snap
@@ -392,6 +392,27 @@ exports[`Generate routes > solid - match snapshot > routes 1`] = `
 ]
 `;
 
+exports[`Generate routes > use route name separator > client code 1`] = `
+"const __pages_import_0__ = () => import(\\"/examples/vue/src/pages/blog/today/index.vue\\");
+const __pages_import_1__ = () => import(\\"/examples/vue/src/pages/blog/index.vue\\");
+import __pages_import_2__ from \\"/examples/vue/src/pages/index.vue\\";
+const __pages_import_3__ = () => import(\\"/examples/vue/src/pages/components.vue\\");
+const __pages_import_4__ = () => import(\\"/examples/vue/src/pages/about.vue\\");
+const __pages_import_5__ = () => import(\\"/examples/vue/src/pages/about/index.vue\\");
+const __pages_import_6__ = () => import(\\"/examples/vue/src/pages/about/[id].vue\\");
+const __pages_import_7__ = () => import(\\"/examples/vue/src/pages/about/[id]/more.vue\\");
+const __pages_import_8__ = () => import(\\"/examples/vue/src/pages/about/[id]/nested.vue\\");
+const __pages_import_9__ = () => import(\\"/examples/vue/src/pages/[...all].vue\\");
+const __pages_import_10__ = () => import(\\"/examples/vue/src/pages/[sensor].vue\\");
+const __pages_import_11__ = () => import(\\"/examples/vue/src/pages/[sensor]/current.vue\\");
+const __pages_import_12__ = () => import(\\"/examples/vue/src/pages/blog/[id].vue\\");
+const __pages_import_13__ = () => import(\\"/examples/vue/src/pages/blog/today/[...all].vue\\");
+
+const routes = [{\\"name\\":\\"blog/today\\",\\"path\\":\\"/blog/today\\",\\"component\\":__pages_import_0__,\\"props\\":true},{\\"name\\":\\"blog\\",\\"path\\":\\"/blog\\",\\"component\\":__pages_import_1__,\\"props\\":true},{\\"name\\":\\"homepage\\",\\"path\\":\\"/\\",\\"component\\":__pages_import_2__,\\"props\\":true,\\"meta\\":{\\"requiresAuth\\":false}},{\\"name\\":\\"components\\",\\"path\\":\\"/components\\",\\"component\\":__pages_import_3__,\\"props\\":true,\\"meta\\":{\\"lang\\":\\"yaml\\"}},{\\"path\\":\\"/about\\",\\"component\\":__pages_import_4__,\\"children\\":[{\\"name\\":\\"about\\",\\"path\\":\\"\\",\\"component\\":__pages_import_5__,\\"props\\":true},{\\"name\\":\\"about-user-id\\",\\"path\\":\\":id\\",\\"component\\":__pages_import_6__,\\"children\\":[{\\"name\\":\\"about/id/more\\",\\"path\\":\\"more\\",\\"component\\":__pages_import_7__,\\"props\\":true},{\\"name\\":\\"about/id/nested\\",\\"path\\":\\"nested\\",\\"component\\":__pages_import_8__,\\"props\\":true}],\\"props\\":true,\\"meta\\":{\\"requiresAuth\\":true}}],\\"props\\":true,\\"meta\\":{\\"lang\\":\\"yml\\"}},{\\"name\\":\\"all\\",\\"path\\":\\"/:all(.*)*\\",\\"component\\":__pages_import_9__,\\"props\\":true},{\\"name\\":\\"sensor\\",\\"path\\":\\"/:sensor\\",\\"component\\":__pages_import_10__,\\"children\\":[{\\"name\\":\\"sensor/current\\",\\"path\\":\\"current\\",\\"component\\":__pages_import_11__,\\"props\\":true}],\\"props\\":true},{\\"name\\":\\"blog-id\\",\\"path\\":\\"/blog/:id\\",\\"component\\":__pages_import_12__,\\"props\\":true,\\"meta\\":{\\"requiresAuth\\":false}},{\\"name\\":\\"blog/today/all\\",\\"path\\":\\"/blog/today/:all(.*)\\",\\"component\\":__pages_import_13__,\\"props\\":true}];
+
+export default routes;"
+`;
+
 exports[`Generate routes > vue - async mode match snapshot > client code 1`] = `
 "const __pages_import_0__ = () => import(\\"/examples/vue/src/pages/[...all].vue\\");
 const __pages_import_1__ = () => import(\\"/examples/vue/src/pages/[sensor].vue\\");

--- a/test/generate.spec.ts
+++ b/test/generate.spec.ts
@@ -116,4 +116,15 @@ describe('Generate routes', () => {
       expect(routes).toMatchSnapshot('client code')
     })
   })
+
+  test('use route name separator', async() => {
+    const ctx = new PageContext({
+      dirs: 'examples/vue/src/pages',
+      routeNameSeparator: '/',
+    })
+    await ctx.searchGlob()
+
+    const routes = await ctx.resolveRoutes()
+    expect(routes).toMatchSnapshot('client code')
+  })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When you change your `routeNameSeparator` to "/" the route generated for `/blog/index.vue` was { name: 'blog/index', ... } 

### Additional context

this fix on `prepareRoutes` to remove the `index` from the name of the route even if we use another `routeNameSeparator` than the default one `-`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
