### PR TITLE
fix: `exclude` is not working as expected.

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -36,10 +36,11 @@ export function getPageFiles(path: string, options: ResolvedOptions): string[] {
 
   const ext = extsToGlob(extensions)
 
-  const files = fg.sync(slash(join(path, `**/*.${ext}`)), {
+  const files = fg.sync(`**/*.${ext}`, {
     ignore: exclude,
     onlyFiles: true,
-  })
+    cwd: path
+  }).map(p => slash(join(path, p)))
 
   return files
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

For example, `my-app` is the project I'm developing and its path on disk is `/xie/__demo__/my-app/`, when I use `vite-plugin-pages` it won't match any path because the default `exclude` option has `**/__*__/**`.

vite.config.ts
```ts
import { defineConfig } from 'vite'
import Vue from '@vitejs/plugin-vue'
import Pages from 'vite-plugin-pages'

export default defineConfig({
  plugins: [
    Vue(),
    Pages({
      dirs: [
        { dir: 'src/pages', baseRoute: 'pages' }
      ]
    })
  ]
})
```

So I think the `exclude` option here should be relative to my `dir` option, this PR resolve the problem.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
