### PR TITLE
feat: add `resolveRouteBlock` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,13 @@ generated routes.
 A function that takes a generated client code and optionally returns a modified
 generated client code.
 
+### resolveRouteBlock
+
+- **Type:** `(content: string, path: string) => Awaitable<CustomBlock | void>`
+
+A function that takes page file content and path, and optionally returns route data.
+
+
 ### SFC custom block for Route Data
 
 Add route meta to the route by adding a `<route>` block to the SFC. This will be

--- a/src/customBlock.ts
+++ b/src/customBlock.ts
@@ -79,6 +79,11 @@ export function parseCustomBlock(block: SFCBlock, filePath: string, options: Res
 export async function getRouteBlock(path: string, options: ResolvedOptions) {
   const content = fs.readFileSync(path, 'utf8')
 
+  if (typeof options.resolveRouteBlock === 'function') {
+    const result = await options.resolveRouteBlock(content, path)
+    if (result) return result
+  }
+
   const parsedSFC = await parseSFC(content)
   const blockStr = parsedSFC?.customBlocks.find(b => b.type === 'route')
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -61,6 +61,7 @@ export function resolveOptions(userOptions: UserOptions, viteRoot?: string): Res
     extendRoute,
     onRoutesGenerated,
     onClientGenerated,
+    resolveRouteBlock,
   } = userOptions
 
   const root = viteRoot || slash(process.cwd())
@@ -97,6 +98,7 @@ export function resolveOptions(userOptions: UserOptions, viteRoot?: string): Res
     onRoutesGenerated,
     onClientGenerated,
     routeNameSeparator,
+    resolveRouteBlock,
   }
 
   return resolvedOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,10 @@ interface Options {
    * Custom generated client code
    */
   onClientGenerated?: (clientCode: string) => Awaitable<string | void>
+  /**
+   * Custom resolve route block
+   */
+  resolveRouteBlock?: (content: string, path: string) => Awaitable<CustomBlock | void>
 
   /**
    * Paths to the directory to search for page components.

--- a/test/__snapshots__/options.spec.ts.snap
+++ b/test/__snapshots__/options.spec.ts.snap
@@ -29,6 +29,7 @@ exports[`Options resolve > react 1`] = `
   ],
   "onClientGenerated": undefined,
   "onRoutesGenerated": undefined,
+  "resolveRouteBlock": undefined,
   "resolver": {
     "getComputedRoutes": [Function],
     "resolveExtensions": [Function],
@@ -75,6 +76,7 @@ exports[`Options resolve > solid 1`] = `
   ],
   "onClientGenerated": undefined,
   "onRoutesGenerated": undefined,
+  "resolveRouteBlock": undefined,
   "resolver": {
     "getComputedRoutes": [Function],
     "resolveExtensions": [Function],
@@ -119,6 +121,7 @@ exports[`Options resolve > vue - custom module id 1`] = `
   ],
   "onClientGenerated": undefined,
   "onRoutesGenerated": undefined,
+  "resolveRouteBlock": undefined,
   "resolver": {
     "getComputedRoutes": [Function],
     "hmr": {
@@ -166,6 +169,7 @@ exports[`Options resolve > vue 1`] = `
   ],
   "onClientGenerated": undefined,
   "onRoutesGenerated": undefined,
+  "resolveRouteBlock": undefined,
   "resolver": {
     "getComputedRoutes": [Function],
     "hmr": {

--- a/test/__snapshots__/parser.spec.ts.snap
+++ b/test/__snapshots__/parser.spec.ts.snap
@@ -18,3 +18,30 @@ exports[`Parser > jsx yaml comment 1`] = `
   "name": "blog-id",
 }
 `;
+
+exports[`Parser > option:resolveRouteBlock > does not meet the condition of resolveRouteBlock 1`] = `
+{
+  "meta": {
+    "requiresAuth": false,
+  },
+  "name": "blog-id",
+}
+`;
+
+exports[`Parser > option:resolveRouteBlock > does not meet the condition of resolveRouteBlock 2`] = `
+{
+  "meta": {
+    "id": 1234,
+    "requiresAuth": false,
+  },
+  "name": "blog-id",
+}
+`;
+
+exports[`Parser > option:resolveRouteBlock > meet the condition of resolveRouteBlock 1`] = `
+{
+  "meta": {
+    "title": "CustomRouteBlock",
+  },
+}
+`;

--- a/test/data/CustomRouteBlock.jsx
+++ b/test/data/CustomRouteBlock.jsx
@@ -1,0 +1,17 @@
+import { defineComponent } from 'vue'
+
+// eslint-disable-next-line no-undef
+definePageRoute({
+  meta: {
+    title: 'CustomRouteBlock',
+  },
+})
+
+export default defineComponent({
+  name: 'CustomRouteBlock',
+  render() {
+    return (
+      <div>CustomRouteBlock</div>
+    )
+  },
+})

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -16,4 +16,37 @@ describe('Parser', () => {
     const routeBlock = await getRouteBlock(path, options)
     expect(routeBlock).toMatchSnapshot()
   })
+
+  describe('option:resolveRouteBlock', () => {
+    const userOptions = resolveOptions({
+      resolveRouteBlock(content, filePath) {
+        const isJsx = filePath.endsWith('.jsx') || filePath.endsWith('.tsx')
+        if (isJsx && content.includes('definePageRoute')) {
+          const RE = /definePageRoute\(([\s\S]*?)\);?/g
+          const body = content.match(RE)?.[0]
+          if (body) {
+            // eslint-disable-next-line no-new-func
+            const routeConfig = new Function(`function definePageRoute(config) { return config }; return ${body}`)()
+            return routeConfig
+          }
+        }
+      },
+    })
+
+    test('meet the condition of resolveRouteBlock', async() => {
+      const path = resolve(__dirname, './data/CustomRouteBlock.jsx')
+      const routeBlock = await getRouteBlock(path, userOptions)
+      expect(routeBlock).toMatchSnapshot()
+    })
+
+    test('does not meet the condition of resolveRouteBlock', async() => {
+      const vueFilePath = resolve('./examples/vue/src/pages/blog/[id].vue')
+      const vueRouteBlock = await getRouteBlock(vueFilePath, userOptions)
+      expect(vueRouteBlock).toMatchSnapshot()
+
+      const jsxFilePath = resolve('./examples/vue/src/pages/jsx.jsx')
+      const jsxRouteBlock = await getRouteBlock(jsxFilePath, userOptions)
+      expect(jsxRouteBlock).toMatchSnapshot()
+    })
+  })
 })


### PR DESCRIPTION
test: update snapshots

<!-- Thank you for contributing! -->

### Description

Add a new configuration option to support custom resolve route block.

**Type:** `(content: string, path: string) => Awaitable<CustomBlock | void>`

### Additional context

`pnpm run test parser` is ok, but `pnpm run test` get error.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
