### PR TITLE
docs: add example in docs for React v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,36 @@ ReactDOM.render(
 )
 ```
 
+Or with React 18 :
+
+```jsx
+import { createRoot } from 'react-dom/client'
+import { Suspense } from 'react'
+import {
+  BrowserRouter as Router,
+  useRoutes,
+} from 'react-router-dom'
+
+import routes from '~react-pages'
+
+const App = () => {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      {useRoutes(routes)}
+    </Suspense>
+  )
+}
+
+const container = document.getElementById('app')
+const root = createRoot(container) // createRoot(container!) if you use TypeScript
+
+root.render(
+  <Router>
+    <App />
+  </Router>,
+)
+```
+
 **Type**
 
 ```ts


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The documentation about React is only available for React <= 17. This PR adds documentation for React 18 and its new way to render the root Element of the React App.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
