### PR TITLE
fix: change virtual module id to prefix with `virtual:`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,8 +7,8 @@ export const MODULE_IDS = [
   'virtual:generated-pages-react',
 ]
 
-export const MODULE_ID_VIRTUAL = 'virtual:@vite-plugin-pages/generated-pages'
-export const ROUTE_BLOCK_ID_VIRTUAL = 'virtual:@vite-plugin-pages/route-block'
+export const MODULE_ID_VIRTUAL = 'virtual:vite-plugin-pages/generated-pages'
+export const ROUTE_BLOCK_ID_VIRTUAL = 'virtual:vite-plugin-pages/route-block'
 export const ROUTE_IMPORT_NAME = '__pages_import_$1__'
 
 export const routeBlockQueryRE = /\?vue&type=route/

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,8 +7,8 @@ export const MODULE_IDS = [
   'virtual:generated-pages-react',
 ]
 
-export const MODULE_ID_VIRTUAL = '/@vite-plugin-pages/generated-pages'
-export const ROUTE_BLOCK_ID_VIRTUAL = '/@vite-plugin-pages/route-block'
+export const MODULE_ID_VIRTUAL = 'virtual:@vite-plugin-pages/generated-pages'
+export const ROUTE_BLOCK_ID_VIRTUAL = 'virtual:@vite-plugin-pages/route-block'
 export const ROUTE_IMPORT_NAME = '__pages_import_$1__'
 
 export const routeBlockQueryRE = /\?vue&type=route/


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

Modify the name of the virtual module to conform to the specification of vite and rollup so that it can be easily used in other frameworks.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

If the name is not standardized, some frameworks will resolve it as an absolute path because the name does not have the `virtual:` identifier and starts with `/`.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
