### PR TITLE
+ cleanRoute in PageOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .idea/
 .pnpm-debug*
 .eslintcache
+vite-plugin-pages-*.tgz

--- a/README.md
+++ b/README.md
@@ -202,9 +202,14 @@ interface PageOptions {
   baseRoute: string
   /**
    * Page file pattern.
-   * @example `**\/*.page.vue`
+   * @example `**\/*.{page,layout}.*`
    */
   filePattern?: string
+  /**
+   * Function to clean or process the route by removing unnecessary parts.
+   * @example (route) => route.replace(/.(page|layout)$/, '')
+   */
+  cleanRoute?: (route:string, path:string)=>string
 }
 ```
 
@@ -246,6 +251,8 @@ export default {
         { dir: 'src/features/**/pages', baseRoute: 'features' },
         // with custom file pattern
         { dir: 'src/admin/pages', baseRoute: 'admin', filePattern: '**/*.page.*' },
+        // with custom file pattern and clean route
+        { dir: 'src/custom/pages', baseRoute: 'custom', filePattern: '**/*.{page,layout}.*', cleanRoute: (route) => route.replace(/.(page|layout)$/, '') },
       ],
     }),
   ],

--- a/src/context.ts
+++ b/src/context.ts
@@ -74,6 +74,7 @@ export class PageContext {
 
   async addPage(path: string | string[], pageDir: PageOptions) {
     debug.pages('add', path)
+    const cleanRoute = pageDir.cleanRoute || ((route:string)=>route);
     for (const p of toArray(path)) {
       const pageDirPath = slash(resolve(this.root, pageDir.dir))
       const extension = this.options.extensions.find(ext => p.endsWith(`.${ext}`))
@@ -83,7 +84,7 @@ export class PageContext {
       const route = slash(join(pageDir.baseRoute, p.replace(`${pageDirPath}/`, '').replace(`.${extension}`, '')))
       this._pageRouteMap.set(p, {
         path: p,
-        route,
+        route: cleanRoute(route, p),
       })
       await this.options.resolver.hmr?.added?.(this, p)
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,9 +36,14 @@ export interface PageOptions {
   filePatern?: string
   /**
    * Page file pattern.
-   * @example `**\/*.page.vue`
+   * @example `**\/*.{page,layout}.*`
    */
   filePattern?: string
+  /**
+   * Function to clean or process the route by removing unnecessary parts.
+   * @example (route) => route.replace(/.(page|layout)$/, '')
+   */
+  cleanRoute?: (route:string, path:string)=>string
 }
 
 export interface PageResolver {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `cleanRoute` function is designed to process and clean routes by removing unnecessary parts of the URL or route string.

### Additional context

In Remix, we can declare a layout with the same name as the directory. However, with `cleanRoute`, we can add a `.layout` suffix to the layout page, making it easier to differentiate between the layout and other pages in the same directory.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
