### PR TITLE
docs: improve solid-js guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ app.render(
 
 #### Passing routes to solid-router
 
-*solid-router newer than v0.9.x*
+This guide is for solid-router v0.10.x and newer. For older versions see the [migration guide](https://github.com/solidjs/solid-router/blob/1c9eb8ed2cb70e4fa5a53d0d2836fc112e8ac4a0/README.md?plain=1#L925).
 
 ```tsx
 import { Router } from '@solidjs/router'
@@ -158,31 +158,9 @@ render(
 )
 ```
 
-*solid-router older than and including v0.9.x* ([migration guide](https://github.com/solidjs/solid-router/blob/1c9eb8ed2cb70e4fa5a53d0d2836fc112e8ac4a0/README.md?plain=1#L925))
-
-```tsx
-import { Router, useRoutes } from '@solidjs/router'
-import { render } from 'solid-js/web'
-import routes from '~solid-pages'
-
-render(
-  () => {
-    const Routes = useRoutes(routes)
-    return (
-      <Router>
-        <Routes />
-      </Router>
-    )
-  },
-  document.getElementById('root') as HTMLElement,
-)
-```
-
 #### Configuring vite-plugin with SolidJS
 
-Remember to check the `dirs` is set to the correct routes directory in `vite.config.ts` or `app.config.ts`:
-
-*vite.config.ts* (without SolidStart)
+Remember to check the `dirs` is set to the correct routes directory in `vite.config.ts`:
 
 ```ts
 import { defineConfig } from 'vite';
@@ -194,22 +172,6 @@ export default defineConfig({
   plugins: [Pages({
     dirs: ['src/pages'],
   }), solidPlugin()],
-});
-```
-
-*app.config.ts* (with SolidStart)
-
-```ts
-import { defineConfig } from "@solidjs/start/config";
-import Pages from 'vite-plugin-pages'
-
-export default defineConfig({
-	ssr: false,
-	vite: {
-		plugins: [Pages({
-			dirs: ['src/routes'],
-		})],
-	}
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ render(
   () => {
     return (
       <Router
-        root={(props) => (
+        root={props => (
           <Suspense>
             {props.children}
           </Suspense>
@@ -163,16 +163,18 @@ render(
 Remember to check the `dirs` is set to the correct routes directory in `vite.config.ts`:
 
 ```ts
-import { defineConfig } from 'vite';
-import solidPlugin from 'vite-plugin-solid';
-import Pages from 'vite-plugin-pages';
-
+import { defineConfig } from 'vite'
+import Pages from 'vite-plugin-pages'
+import solidPlugin from 'vite-plugin-solid'
 
 export default defineConfig({
-  plugins: [Pages({
-    dirs: ['src/pages'],
-  }), solidPlugin()],
-});
+  plugins: [
+    Pages({
+      dirs: ['src/pages'],
+    }),
+    solidPlugin()
+  ],
+})
 ```
 
 **Type**

--- a/README.md
+++ b/README.md
@@ -131,7 +131,34 @@ app.render(
 
 ### Solid
 
-**experimental**
+#### Passing routes to solid-router
+
+*solid-router newer than v0.9.x*
+
+```tsx
+import { Router } from '@solidjs/router'
+import { render } from 'solid-js/web'
+import routes from '~solid-pages'
+
+render(
+  () => {
+    return (
+      <Router
+        root={(props) => (
+          <Suspense>
+            {props.children}
+          </Suspense>
+        )}
+      >
+        {routes}
+      </Router>
+    )
+  },
+  document.getElementById('root') as HTMLElement,
+)
+```
+
+*solid-router older than and including v0.9.x* ([migration guide](https://github.com/solidjs/solid-router/blob/1c9eb8ed2cb70e4fa5a53d0d2836fc112e8ac4a0/README.md?plain=1#L925))
 
 ```tsx
 import { Router, useRoutes } from '@solidjs/router'
@@ -149,6 +176,41 @@ render(
   },
   document.getElementById('root') as HTMLElement,
 )
+```
+
+#### Configuring vite-plugin with SolidJS
+
+Remember to check the `dirs` is set to the correct routes directory in `vite.config.ts` or `app.config.ts`:
+
+*vite.config.ts* (without SolidStart)
+
+```ts
+import { defineConfig } from 'vite';
+import solidPlugin from 'vite-plugin-solid';
+import Pages from 'vite-plugin-pages';
+
+
+export default defineConfig({
+  plugins: [Pages({
+    dirs: ['src/pages'],
+  }), solidPlugin()],
+});
+```
+
+*app.config.ts* (with SolidStart)
+
+```ts
+import { defineConfig } from "@solidjs/start/config";
+import Pages from 'vite-plugin-pages'
+
+export default defineConfig({
+	ssr: false,
+	vite: {
+		plugins: [Pages({
+			dirs: ['src/routes'],
+		})],
+	}
+});
 ```
 
 **Type**


### PR DESCRIPTION
This expands on the documentation for use with solid.

This PR adds guidance how to configure the solid-router with the later/current versions, where the Readme.md currently only include an example of a somewhat obsolete version.

This PR also adds guidance on how to configure the vite plugin in a scenario with and without SolidStart.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
